### PR TITLE
Add Total Empeño KPI to Home Page

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
+use Exception;
+
+class HomeController extends Controller
+{
+    public function index()
+    {
+        // List of database suffixes provided by the user (1-22, skipping 12)
+        $suffixes = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+            11, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22
+        ];
+
+        $totalEmpeno = 0;
+
+        // Default to current month if not specified
+        // The user's query uses @fechaDel and @fechaAl.
+        // We assume "This Month" unless specified otherwise.
+        $fechaDel = Carbon::now()->startOfMonth()->toDateString();
+        $fechaAl = Carbon::now()->endOfMonth()->toDateString();
+
+        // Base connection configuration (using the default sqlsrv connection as a template)
+        // Ensure 'sqlsrv' is defined in config/database.php
+        $baseConfig = Config::get('database.connections.sqlsrv');
+
+        if (!$baseConfig) {
+            // Fallback or error if sqlsrv is not configured
+            Log::error("SQL Server connection 'sqlsrv' is not configured.");
+            return view('employees.home', ['totalEmpeno' => 0, 'error' => 'Database configuration missing']);
+        }
+
+        foreach ($suffixes as $suffix) {
+            $dbName = 'sistema_prendario_' . $suffix;
+            $connectionName = 'dynamic_sqlsrv';
+
+            try {
+                // Clone the base config and update the database name
+                $config = $baseConfig;
+                $config['database'] = $dbName;
+
+                // Set the dynamic connection configuration
+                Config::set("database.connections.{$connectionName}", $config);
+
+                // Purge the connection to ensure fresh connection with new config
+                DB::purge($connectionName);
+
+                // Run the query
+                // We use the simplified logic: Sum prestamo for contracts with movements 1,2,3,4 in the date range
+                // and active contracts (f_cancelacion IS NULL)
+                // Note: The user's query uses CAST(mo.f_alta AS DATE), which is T-SQL specific.
+
+                // We fetch the sum directly.
+                // The query filters:
+                // - Active contracts (f_cancelacion IS NULL)
+                // - Movements of type 1, 2, 3, 4
+                // - Date range on movement creation date
+                // - Pledge types 1, 2, 3 (Alhajas, Autos, Varios)
+                $query = "
+                    SELECT SUM(con.prestamo) as total
+                    FROM movimientos mo
+                    INNER JOIN contratos con ON con.cod_contrato = mo.cod_contrato
+                    INNER JOIN usuarios us ON us.cod_usuario = mo.cod_usuario
+                    INNER JOIN tipo_movimiento tm ON tm.cod_tipo_movimiento = mo.cod_tipo_movimiento
+                    WHERE con.f_cancelacion IS NULL
+                    AND mo.cod_tipo_movimiento IN (1, 2, 3, 4)
+                    AND CAST(mo.f_alta AS DATE) BETWEEN ? AND ?
+                    AND con.cod_tipo_prenda IN (1, 2, 3)
+                ";
+
+                // We use selectOne to get a single row result
+                $result = DB::connection($connectionName)->selectOne($query, [$fechaDel, $fechaAl]);
+
+                if ($result && isset($result->total)) {
+                    $totalEmpeno += $result->total;
+                }
+
+            } catch (Exception $e) {
+                // Log the error
+                Log::error("Error connecting to or querying {$dbName}: " . $e->getMessage());
+                // Continue to next database
+            }
+        }
+
+        return view('employees.home', compact('totalEmpeno'));
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class User extends Authenticatable
 {
-    use Notifiable;
+    use HasFactory, Notifiable;
 
     protected $fillable = [
         'nombre',

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,21 +24,12 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
+            'nombre' => fake()->firstName(),
+            'primer_apellido' => fake()->lastName(),
+            'segundo_apellido' => fake()->lastName(),
+            'nick_name' => fake()->unique()->userName(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];
-    }
-
-    /**
-     * Indicate that the model's email address should be unverified.
-     */
-    public function unverified(): static
-    {
-        return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
-        ]);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,14 @@
 {
-    "name": "powerbi",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "@popperjs/core": "^2.11.8",
+                "bootstrap": "^5.3.8",
+                "bootstrap-icons": "^1.13.1"
+            },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/vite": "^4.0.0",
@@ -600,6 +605,16 @@
             "optional": true,
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1377,6 +1392,41 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/bootstrap": {
+            "version": "5.3.8",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+            "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ],
+            "license": "MIT",
+            "peerDependencies": {
+                "@popperjs/core": "^2.11.8"
+            }
+        },
+        "node_modules/bootstrap-icons": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+            "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "2.0.2",

--- a/resources/views/employees/home.blade.php
+++ b/resources/views/employees/home.blade.php
@@ -11,8 +11,28 @@
 <div class="container-fluid p-4">
 	<div class="row mb-4">
 		<div class="col-12 d-flex justify-content-between align-items-center">
-			<h4 class="title">Bienvenido,  </h4>
-			
+			<h4 class="title">Bienvenido, {{ Auth::user()->nombre_completo ?? Auth::user()->nombre ?? '' }}</h4>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12 col-md-6 col-lg-4">
+			<div class="card shadow-sm border-0">
+				<div class="card-body">
+					<h5 class="card-title text-muted mb-3">Total Empeño (Mes Actual)</h5>
+					<div class="d-flex align-items-center">
+						<div class="flex-grow-1">
+							<h2 class="mb-0 font-weight-bold text-primary">$ {{ number_format($totalEmpeno ?? 0, 2) }}</h2>
+						</div>
+						<div class="icon-shape bg-light text-primary rounded-circle p-3">
+							<i class="bi bi-cash-coin fs-1"></i>
+						</div>
+					</div>
+					<p class="mt-3 mb-0 text-muted text-sm">
+						<span class="text-nowrap">Acumulado de todas las sucursales</span>
+					</p>
+				</div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\HomeController;
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use Illuminate\Support\Facades\Route;
 
@@ -8,9 +9,7 @@ Route::get('/', [AuthenticatedSessionController::class, 'create']);
 Route::post('/login', [AuthenticatedSessionController::class, 'store'])->name('login');
 Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
 
-Route::get('/home', function () {
-    return view('employees.home');
-})->middleware(['auth'])->name('home');
+Route::get('/home', [HomeController::class, 'index'])->middleware(['auth'])->name('home');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
Implemented the "Total Empeño" KPI on the home page as requested. The KPI calculates the sum of `con.prestamo` for movements of type 1 (Empeño) and others (Refrendo, etc.) within the current month, across all specified databases (suffixes 1-22, excluding 12). Handles connection failures gracefully. Also updated the User model and factory to align with the database schema.

---
*PR created automatically by Jules for task [599051516306268196](https://jules.google.com/task/599051516306268196) started by @ROBERTO5599*