### PR TITLE
Use precise datetime filtering for KPI

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -20,9 +20,9 @@ class HomeController extends Controller
         $totalEmpeno = 0;
         $sucursalesDetalle = []; // To store name and total per branch
 
-        // Default to current month if not specified
-        $fechaDel = Carbon::now()->startOfMonth()->toDateString();
-        $fechaAl = Carbon::now()->endOfMonth()->toDateString();
+        // Default to current month with precise time boundaries
+        $fechaDel = Carbon::now()->startOfMonth()->format('Y-m-d H:i:s');
+        $fechaAl = Carbon::now()->endOfMonth()->format('Y-m-d H:i:s');
 
         // Base connection configuration (using the default mysql connection as a template)
         $baseConfig = Config::get('database.connections.mysql');
@@ -56,14 +56,16 @@ class HomeController extends Controller
                 // Purge the connection to ensure fresh connection with new config
                 DB::purge($connectionName);
 
-                // Updated Query: Only movement type 1 (Empeño)
+                // Updated Query:
+                // - Only movement type 1 (Empeño)
+                // - Filter on mo.f_alta using precise DATETIME range (no CAST AS DATE)
                 $query = "
                     SELECT SUM(con.prestamo) as total
                     FROM movimientos mo
                     INNER JOIN contratos con ON con.cod_contrato = mo.cod_contrato
                     WHERE con.f_cancelacion IS NULL
                     AND mo.cod_tipo_movimiento IN (1)
-                    AND CAST(mo.f_alta AS DATE) BETWEEN ? AND ?
+                    AND mo.f_alta BETWEEN ? AND ?
                     AND con.cod_tipo_prenda IN (1, 2, 3)
                 ";
 

--- a/resources/views/employees/home.blade.php
+++ b/resources/views/employees/home.blade.php
@@ -16,7 +16,7 @@
 <div class="container-fluid p-4">
 	<div class="row mb-4">
 		<div class="col-12 d-flex justify-content-between align-items-center">
-			<h4 class="title">Bienvenido, {{ Auth::user()->nombre_completo ?? Auth::user()->nombre ?? '' }} (del {{ \Carbon\Carbon::parse($fechaDel)->format('d/m/Y') }} al {{ \Carbon\Carbon::parse($fechaAl)->format('d/m/Y') }})</h4>
+			<h4 class="title">Bienvenido, {{ Auth::user()->nombre_completo ?? Auth::user()->nombre ?? '' }} (del {{ \Carbon\Carbon::parse($fechaDel)->format('d/m/Y H:i') }} al {{ \Carbon\Carbon::parse($fechaAl)->format('d/m/Y H:i') }})</h4>
 		</div>
 	</div>
 
@@ -53,7 +53,7 @@
       </div>
       <div class="modal-body">
 		<div class="alert alert-info py-2 mb-3">
-			<small>Periodo: <strong>{{ \Carbon\Carbon::parse($fechaDel)->format('d/m/Y') }}</strong> al <strong>{{ \Carbon\Carbon::parse($fechaAl)->format('d/m/Y') }}</strong></small>
+			<small>Periodo: <strong>{{ \Carbon\Carbon::parse($fechaDel)->format('d/m/Y H:i') }}</strong> al <strong>{{ \Carbon\Carbon::parse($fechaAl)->format('d/m/Y H:i') }}</strong></small>
 		</div>
         <ul class="list-group list-group-flush">
 			@if(isset($sucursalesDetalle) && count($sucursalesDetalle) > 0)


### PR DESCRIPTION
- Updated `HomeController` to use full datetime strings for the query range (`BETWEEN ? AND ?`) instead of just dates.
- Removed `CAST(mo.f_alta AS DATE)` to ensure transactions occurring at any time on the start/end dates are correctly included.
- Updated the view to display the date range with time (`d/m/Y H:i`) in both the welcome message and the modal.