### PR TITLE
Embed dates directly in KPI query for debugging/consistency

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -59,17 +59,18 @@ class HomeController extends Controller
                 // Updated Query:
                 // - Only movement type 1 (Empeño)
                 // - Filter on mo.f_alta using precise DATETIME range using CAST AS DATE as requested
+                // - Embedding dates directly into query string for precise control/debugging
                 $query = "
                     SELECT SUM(con.prestamo) as total
                     FROM movimientos mo
                     INNER JOIN contratos con ON con.cod_contrato = mo.cod_contrato
                     WHERE con.f_cancelacion IS NULL
                     AND mo.cod_tipo_movimiento IN (1)
-                    AND CAST(mo.f_alta AS DATE) BETWEEN ? AND ?
+                    AND CAST(mo.f_alta AS DATE) BETWEEN '$fechaDel' AND '$fechaAl'
                     AND con.cod_tipo_prenda IN (1, 2, 3)
                 ";
 
-                $result = DB::connection($connectionName)->selectOne($query, [$fechaDel, $fechaAl]);
+                $result = DB::connection($connectionName)->selectOne($query);
 
                 if ($result && isset($result->total)) {
                     $sucursalTotal = $result->total;


### PR DESCRIPTION
- Embedded `$fechaDel` and `$fechaAl` directly into the SQL query string for the KPI calculation.
- This helps verify the query behaves exactly as tested in MySQL clients, avoiding any potential parameter binding ambiguity with `CAST(... AS DATE)`.