### PR TITLE
Add Resumen Ejecutivo to sidebar and fix route access

### DIFF
--- a/resources/views/employees/layouts/main.blade.php
+++ b/resources/views/employees/layouts/main.blade.php
@@ -154,6 +154,9 @@
                 <a href="{{ url('/home') }}" class="list-group-item list-group-item-action">
                     <i class="bi bi-house-fill me-2"></i>Inicio
                 </a>
+                <a href="{{ route('resumen-ejecutivo.index') }}" class="list-group-item list-group-item-action">
+                    <i class="bi bi-bar-chart-line me-2"></i>Resumen Ejecutivo
+                </a>
                 <a class="list-group-item list-group-item-action" href="{{ route('logout') }}"
                    onclick="event.preventDefault();
                                  document.getElementById('logout-form').submit();">


### PR DESCRIPTION
- Added a navigation link to 'Resumen Ejecutivo' in `resources/views/employees/layouts/main.blade.php`.
- The controller `ResumenEjecutivoController` handles both the initial view and filtering via the same `index` method, supporting the user's requirement for a single route.
- Ensured the dashboard layout includes the new link for easy access.