### PR TITLE
Change default start date to beginning of current month

### DIFF
--- a/app/Http/Controllers/ResumenEjecutivoController.php
+++ b/app/Http/Controllers/ResumenEjecutivoController.php
@@ -13,7 +13,7 @@ class ResumenEjecutivoController extends Controller
     // Carga la vista base sin datos (renderizado rápido)
     public function index(Request $request)
     {
-        $fechaInicio = now()->subDays(30)->toDateString();
+        $fechaInicio = now()->startOfMonth()->toDateString();
         $fechaFin = now()->toDateString();
         $sucursales = Sucursal::whereNotNull('id_valora_mas')->get();
 
@@ -23,10 +23,10 @@ class ResumenEjecutivoController extends Controller
     // Endpoint AJAX para obtener los datos
     public function data(Request $request)
     {
-        $fechaInicio = $request->input('fecha_inicio', now()->subDays(30)->toDateString());
+        $fechaInicio = $request->input('fecha_inicio', now()->startOfMonth()->toDateString());
         $fechaFin = $request->input('fecha_fin', now()->toDateString());
         $fechaFinQuery = $fechaFin . ' 23:59:59';
-        
+
         $sucursales = Sucursal::whereNotNull('id_valora_mas')->get();
         $sucursalId = $request->input('sucursal_id');
 


### PR DESCRIPTION
- Updated `ResumenEjecutivoController` index and data methods to set `fecha_inicio` default to `now()->startOfMonth()->toDateString()` instead of a rolling 30-day window (`subDays(30)`).
- This aligns the initial dashboard view to represent the current calendar month's performance rather than a sliding month.