### PR TITLE
Update Gastos query to join with movimientos

### DIFF
--- a/app/Http/Controllers/ResumenEjecutivoController.php
+++ b/app/Http/Controllers/ResumenEjecutivoController.php
@@ -76,9 +76,13 @@ class ResumenEjecutivoController extends Controller
 
                 // 1. GASTOS (Egresos)
                 $gastosResult = DB::connection($connectionName)->selectOne("
-                    SELECT COALESCE(SUM(solicitado), 0) AS TotalGastos
-                    FROM gastos
-                    WHERE activo = 1 AND cod_estatus = 2 AND f_solicitado BETWEEN :fechaDel AND :fechaAl
+                    SELECT COALESCE(SUM(gas.solicitado), 0) AS TotalGastos
+                    FROM gastos gas
+                    INNER JOIN movimientos mov ON gas.cod_movimiento = mov.cod_movimiento
+                    WHERE gas.activo = 1
+                      AND gas.cod_estatus = 2
+                      AND gas.f_solicitado >= :fechaDel
+                      AND gas.f_solicitado <= :fechaAl
                 ", [':fechaDel' => $fechaInicio, ':fechaAl' => $fechaFinQuery]);
 
                 $b_egresos = (float)($gastosResult->TotalGastos ?? 0);


### PR DESCRIPTION
- Updated the SQL query for `gastosResult` in `ResumenEjecutivoController` to include an `INNER JOIN` on the `movimientos` table, matching the logic provided from the C# LINQ query.
- Ensured it explicitly filters for active expenses (`activo = 1`) that are confirmed (`cod_estatus = 2`).